### PR TITLE
Fixed Auth

### DIFF
--- a/SocialCoder.Web/Server/Controllers/AuthController.cs
+++ b/SocialCoder.Web/Server/Controllers/AuthController.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
@@ -30,7 +31,8 @@ public class AuthController : ControllerBase
     [HttpPost]
     public async Task<IActionResult> Logout()
     {
-        await _signInManager.SignOutAsync();
+        //await _signInManager.SignOutAsync();
+        await HttpContext.SignOutAsync();
         return Ok();
     }
 
@@ -44,6 +46,9 @@ public class AuthController : ControllerBase
 
         return Challenge(props, scheme);
     }
+
+    [HttpGet, Authorize]
+    public IActionResult TestAuth() => Redirect("~/");
 
     #region OAuth Callbacks (IDK Why but these were needed for this to work)
     [Route("/signin-discord")]
@@ -76,8 +81,9 @@ public class AuthController : ControllerBase
 
             if (!response.Success || response.Data is null)
                 return BadRequest(response.Message);
-            
-            await _signInManager.SignInAsync(response.Data, isPersistent: false);
+    
+            //await HttpContext.SignInAsync(response.Data);
+            await _signInManager.SignInAsync(response.Data, isPersistent: false, CookieAuthenticationDefaults.AuthenticationScheme);
             return Redirect("~/");
         }
         catch (Exception ex)

--- a/SocialCoder.Web/Server/Controllers/AuthController.cs
+++ b/SocialCoder.Web/Server/Controllers/AuthController.cs
@@ -31,8 +31,7 @@ public class AuthController : ControllerBase
     [HttpPost]
     public async Task<IActionResult> Logout()
     {
-        //await _signInManager.SignOutAsync();
-        await HttpContext.SignOutAsync();
+        await _signInManager.SignOutAsync();
         return Ok();
     }
 
@@ -79,7 +78,6 @@ public class AuthController : ControllerBase
             if (!response.Success || response.Data is null)
                 return BadRequest(response.Message);
     
-            //await HttpContext.SignInAsync(response.Data);
             await _signInManager.SignInAsync(response.Data, isPersistent: false, CookieAuthenticationDefaults.AuthenticationScheme);
             return Redirect("~/");
         }

--- a/SocialCoder.Web/Server/Controllers/AuthController.cs
+++ b/SocialCoder.Web/Server/Controllers/AuthController.cs
@@ -47,9 +47,6 @@ public class AuthController : ControllerBase
         return Challenge(props, scheme);
     }
 
-    [HttpGet, Authorize]
-    public IActionResult TestAuth() => Redirect("~/");
-
     #region OAuth Callbacks (IDK Why but these were needed for this to work)
     [Route("/signin-discord")]
     public Task<IActionResult> SignInDiscord() => Task.FromResult<IActionResult>(Ok());

--- a/SocialCoder.Web/Server/Program.cs
+++ b/SocialCoder.Web/Server/Program.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using SocialCoder.Web.Server;
@@ -26,7 +27,7 @@ builder.Services.Configure<IdentityOptions>(options =>
     options.Lockout.DefaultLockoutTimeSpan = TimeSpan.FromMinutes(30);
     options.Lockout.MaxFailedAccessAttempts = 5;
     options.Lockout.AllowedForNewUsers = true;
-
+    
     options.User.RequireUniqueEmail = true;
     options.User.AllowedUserNameCharacters = "1234567890-_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz ";
 });
@@ -47,7 +48,7 @@ builder.Services.ConfigureApplicationCookie(options =>
     };
 });
 
-builder.Services.AddAuthentication("MainCookie")
+builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
     .AddGoogle(options =>
     {
         options.SignInScheme = IdentityConstants.ExternalScheme;
@@ -61,7 +62,8 @@ builder.Services.AddAuthentication("MainCookie")
         options.ClientSecret = builder.Configuration["Authentication:Discord:ClientSecret"];
         options.Scope.Add("identify");
         options.Scope.Add("email");
-    });
+    })
+    .AddCookie();
 
 
 builder.Services.AddControllersWithViews();

--- a/SocialCoder.Web/Server/Services/Implementations/UserService.cs
+++ b/SocialCoder.Web/Server/Services/Implementations/UserService.cs
@@ -35,7 +35,7 @@ public class UserService : IUserService
             _logger.LogError("Unable to determine user from external login provider: {AuthScheme}", authProvider);
             return ResultOf<ApplicationUser>.Fail("Unknown User");
         }
-
+        
         var email = claims.FirstOrDefault(x => x.Type == ClaimTypes.Email)?.Value ?? string.Empty;
         var name = claims.FirstOrDefault(x => x.Type == ClaimTypes.Name)?.Value ?? email;
         


### PR DESCRIPTION
Fixes: #23 

So it appears like the authentication was using the incorrect cookie / not setup correctly.

- On the frontend we used the cookie and were able to go "YAY I am authenticated!" however when we made requests to restricted API endpoints -- we were not authenticated. Our cookie wasn't being utilized.

By adding `AddCookie` and default authentication scheme as cookie - I was able to achieve authenticated HttpClient requests from the client to server.