### PR TITLE
Ability to login via github

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -86,3 +86,14 @@ the following services:
     - Add Authorized `JavaScript origins`: `https://localhost:7159`
     - Authorized Redirect URIs: `https://localhost:7159/signin-google`
     - Save and grab the `Client ID` and `Client Secret`. Shove this into `Google`. Should be self explanatory that the pattern here is `ProviderName` equals the Service name we're using for OAuth.
+
+#### Github
+
+[Register Github App](https://github.com/settings/applications/new)
+
+- Application name can be whatever you want for testing purposes.
+- Homepage URL
+  - https://github.com/Programming-Simplified-Community/Social-Coder
+- Authorization callback URL
+  - https://localhost:7159/signin-github
+- Grab the ClientID, and ClientSecret and put them in the `appsettings.development.json` file under `Github`

--- a/SocialCoder.Web/Client/Pages/Login.razor
+++ b/SocialCoder.Web/Client/Pages/Login.razor
@@ -35,7 +35,7 @@ else
                                 "twitter" => Icons.Custom.Brands.Twitter,
                                 "instagram" => Icons.Custom.Brands.Instagram,
                                 _ => Icons.Filled.QuestionMark
-                                };
+                            };
 
                             var challengeUrl = $"/api/auth/challenge/{provider.Name}";
                             <MudNavLink Href="@challengeUrl" Icon="@icon">@provider.DisplayName</MudNavLink>

--- a/SocialCoder.Web/Server/Controllers/AuthController.cs
+++ b/SocialCoder.Web/Server/Controllers/AuthController.cs
@@ -52,6 +52,9 @@ public class AuthController : ControllerBase
 
     [Route("/signin-google")]
     public Task<IActionResult> SignInGoogle() => Task.FromResult<IActionResult>(Ok());
+
+    [Route("/signin-github")]
+    public Task<IActionResult> SignInGithub() => Task.FromResult<IActionResult>(Ok());
     #endregion
 
     /// <summary>

--- a/SocialCoder.Web/Server/Program.cs
+++ b/SocialCoder.Web/Server/Program.cs
@@ -73,6 +73,20 @@ builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationSc
         options.Scope.Add("identify");
         options.Scope.Add("email");
     })
+    .AddGitHub(options =>
+    {
+        options.SignInScheme = IdentityConstants.ExternalScheme;
+        options.ClientId = builder.Configuration["Authentication:Github:ClientId"];
+        options.ClientSecret = builder.Configuration["Authentication:Github:ClientSecret"];
+
+        options.Scope.Add("public_repo");
+        options.Scope.Add("read:org");
+        options.Scope.Add("gist");
+        options.Scope.Add("read:user");
+        options.Scope.Add("user:email");
+        options.Scope.Add("user:follow");
+        options.Scope.Add("read:project");
+    })
     .AddCookie();
 
 

--- a/SocialCoder.Web/Server/SocialCoder.Web.Server.csproj
+++ b/SocialCoder.Web/Server/SocialCoder.Web.Server.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AspNet.Security.OAuth.GitHub" Version="6.0.11" />
     <PackageReference Include="Discord.OAuth2.AspNetCore" Version="3.0.0" />
     <PackageReference Include="HotChocolate" Version="13.0.0-preview.48" />
     <PackageReference Include="HotChocolate.Abstractions" Version="13.0.0-preview.48" />

--- a/SocialCoder.Web/Shared/ClaimConstants.cs
+++ b/SocialCoder.Web/Shared/ClaimConstants.cs
@@ -1,0 +1,14 @@
+﻿namespace SocialCoder.Web.Shared;
+
+public static class ClaimConstants
+{
+    /// <summary>
+    /// User's alternative name on github
+    /// </summary>
+    public const string GITHUB_NAME = "urn:github:name";
+    
+    /// <summary>
+    /// User's endpoint for github
+    /// </summary>
+    public const string GITHUB_URL = "urn:github:url";
+}


### PR DESCRIPTION
Completes: #4 

A user can now choose to register with our application via Github, Discord, or Google.

Considering we're after a developer-based social media experience we attempt to retrieve a bit more information from Github.
Mostly read-only access to projects, repos, etc. Stuff developers would be interested in, wanting to share that's available publicly.